### PR TITLE
Support icon-prefixed README headings

### DIFF
--- a/install.py
+++ b/install.py
@@ -30,6 +30,13 @@ else:
     long_description = SUMMARY
 
 
+def _normalized_readme_heading(section: str) -> str:
+    """Return a README heading name without decorative leading/trailing icons."""
+    match = re.search(r"^##\s+(.*?)\s*$", section, flags=re.MULTILINE)
+    heading = match.group(1) if match else section.lstrip().partition("\n")[0]
+    return re.sub(r"^[^\w]+|[^\w]+$", "", heading).strip()
+
+
 def _readme2doc(
     readme: str,
     name: str = NAME,
@@ -39,7 +46,7 @@ def _readme2doc(
 ) -> tuple[str, str]:
     doc, rd = "", ""
     for i, s in enumerate(rsplit("\n## ", readme)):
-        head = re.search(" .*\n", s).group()[1:-1]
+        head = _normalized_readme_heading(s)
         if i == 0:
             s = re.sub("^\n# .*", f"\n# {name}", s)
         elif head == "Requirements":
@@ -65,7 +72,12 @@ def _readme2doc(
                 ),
             )
         elif head == "License":
-            s = f"\n## License\nThis project falls under the {pkg_license}.\n"
+            s = re.sub(
+                r"(^##\s+.*\n).*",
+                f"\\1This project falls under the {pkg_license}.\n",
+                s,
+                flags=re.DOTALL | re.MULTILINE,
+            )
 
         rd += s
         if head not in {"Installation", "Requirements", "History"}:


### PR DESCRIPTION
### Motivation
- README section headings may include decorative icons/emojis (e.g. `## 🛠️ Installation`) which prevented correct section matching and generation of install/requirements/license snippets.

### Description
- Add `_normalized_readme_heading(section: str)` which strips decorative leading/trailing characters from a `##` heading before matching. 
- Use `_normalized_readme_heading` in `_readme2doc` instead of the previous inline regex to recognize icon-prefixed headings. 
- Update `License` section replacement to preserve the original (possibly decorated) heading line while injecting the generated license text. 
- Changes are contained in `install.py` and maintain existing behavior for non-decorated headings.

### Testing
- Ran `python -m py_compile install.py` which succeeded. 
- Executed an inline Python test that mocks `cfgtools` and `re_extensions` and verifies that icon-prefixed `Installation`, `Requirements`, and `History` headings are recognized and handled; the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faad1a8d2c832aab46869bf67dcc67)